### PR TITLE
fix lack of no-tls ingress host

### DIFF
--- a/devspace.yaml
+++ b/devspace.yaml
@@ -27,7 +27,7 @@ commands:
   - name: deploy-devspace-cloud
     command: "devspace deploy --namespace=devspace-cloud"
   - name: deploy-devspace-cloud-no-tls
-    command: 'devspace deploy --profile=no-tls --namespace=devspace-cloud --var DOMAIN=""'
+    command: 'devspace deploy --profile=no-tls --namespace=devspace-cloud'
 vars:
   - name: DATABASE_PASSWORD
     source: input


### PR DESCRIPTION
make the devspace-ingress have a host when using deploy-devspace-cloud-no-tls

fixes #13 